### PR TITLE
Add test based on LinearModel example

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import subprocess
+
+import pytest
+import shutil
+
+@pytest.fixture(scope="session")
+def temp_examples_dir(request, tmp_path_factory):
+    """Clone PET Examples repo to a temp dir. Return its path."""
+    pth = tmp_path_factory.mktemp("temp_dir")
+    subprocess.run(["git", "clone", "--depth", "1",
+                    "https://github.com/patnr/PET-Examples.git", pth],
+                   check=True)
+    yield pth
+    shutil.rmtree(str(pth))

--- a/tests/test_linear.py
+++ b/tests/test_linear.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from pathlib import Path, PosixPath
+
+import numpy as np
+import subprocess
+
+# Logger (since we cannot print during testing)
+# -- there is probably a more official way to do this.
+logfile = Path.cwd() / "PET-test-log"
+with open(logfile, "w") as file:
+    pass
+def prnt(*args, **kwargs):
+    with open(logfile, "a") as file:
+        print(*args, **kwargs, file=file)
+
+
+def test_git_clone(temp_examples_dir):
+    # prnt(cwd)
+    # prnt(os.listdir(cwd))
+    assert (temp_examples_dir / "3Spot").is_dir()
+
+
+def test_mod(temp_examples_dir: PosixPath):
+    """Validate a few values of the result of the `LinearModel` example."""
+    cwd = temp_examples_dir / "LinearModel"
+    old = Path.cwd()
+
+    try:
+        os.chdir(cwd)
+        sys.path.append(str(cwd))
+        subprocess.run(["python", "write_true_and_data.py"], cwd=temp_examples_dir)
+        import run_script
+    finally:
+        os.chdir(old)
+
+    result = run_script.assimilation.ensemble.state['permx'].mean(axis=1)
+    np.testing.assert_array_almost_equal(
+        result[[1, 2, 3, -3, -2, -1]],
+        [-0.07294738, 0.00353635, -0.06393236, 0.45394362, 0.44388684, 0.37096157],
+        decimal=5)


### PR DESCRIPTION
We want to have tests based on top-level tasks (DA, optimisation). They should validate the final result against old values (i.e. must not change seed without changing values). This PR does so.

But it's quite hacky because we have to go and clone the examples repo.

I therefore recommend creating some simpler cases that reside solely in this main repo (possibly within the `tests` dir). They should be used to validate all methods against their pre-recorded output. PS: IMHO comparison to theoretical values don't need to be part of _automated_ test suite, but it's an interesting question.