### PR TITLE
Fix CI-test

### DIFF
--- a/pipt/geostat/decomp.py
+++ b/pipt/geostat/decomp.py
@@ -232,11 +232,11 @@ class Cholesky:
         ST 18/6-15: Wholesale copy of code written by Kristian Fossum. Some modifications have been made...
         """
         # Rotation matrix
-        rot_mat = np.matrix([[np.cos((rotate / 180) * np.pi), -np.sin((rotate / 180) * np.pi)],
+        rot_mat = np.array([[np.cos((rotate / 180) * np.pi), -np.sin((rotate / 180) * np.pi)],
                             [np.sin((rotate / 180) * np.pi), np.cos((rotate / 180) * np.pi)]])
 
         # Compressing matrix (since aspect>=1)
-        rescale_mat = np.matrix([[1, 0], [0, aspect]])
+        rescale_mat = np.array([[1, 0], [0, aspect]])
 
         # Coordinates
         dp = v1 - v2

--- a/pipt/update_schemes/enrml.py
+++ b/pipt/update_schemes/enrml.py
@@ -15,13 +15,17 @@ import numpy as np
 import copy as cp
 from scipy.linalg import cholesky, solve
 
+import importlib.util
+
 # List all available packages in the namespace package
 # Import those that are present
 import pipt.update_schemes.update_methods_ns as ns_pkg
 tot_ns_pkg = []
 # extract all class methods from namespace
 for finder, name, ispkg in pkgutil.walk_packages(ns_pkg.__path__):
-    _module = finder.find_module(name).load_module(f'{name}')
+    spec = finder.find_spec(name)
+    _module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_module)
     tot_ns_pkg.extend(inspect.getmembers(_module, inspect.isclass))
 
 # import standard libraries

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'psutil',
         'pdoc @ git+https://github.com/patnr/pdoc@main',
         'pytest',
-        'pandas>=1.5,<2', # libecalc 8.9.0 has requirement pandas<2,>=1
+        'pandas', # libecalc 8.9.0 has requirement pandas<2,>=1
         'p_tqdm',
         'mat73',
         'opencv-python',


### PR DESCRIPTION
In the setup before this PR the CI was restricted to Numpy V1.24.4. This was caused by a restriction on Pandas in the PET setup.py combined with multiple package version restrictions in eCalc. We want the CI to test for newer versions of Numpy. In addition, the PR makes adjustments to remove depreciation warnings.