### PR TITLE
NE in pipt file is now used instead of the whole loaded ensemble 

### DIFF
--- a/ensemble/ensemble.py
+++ b/ensemble/ensemble.py
@@ -134,14 +134,24 @@ class Ensemble:
                 # individually).
                 self.state = {key: val for key, val in tmp_load.items()}
 
-                # Find the number of ensemble members from state variable
+                # Find the number of ensemble members from loaded state variables
                 tmp_ne = []
                 for tmp_state in self.state.keys():
                     tmp_ne.extend([self.state[tmp_state].shape[1]])
-                if max(tmp_ne) != min(tmp_ne):
-                    print('\033[1;33mInput states have different ensemble size\033[1;m')
-                    sys.exit(1)
-                self.ne = min(tmp_ne)
+
+                if 'ne' not in self.keys_en: # NE not specified in input file
+                    if max(tmp_ne) != min(tmp_ne): #Check loaded ensembles are the same size (if more than one state variable)
+                        print('\033[1;33mInput states have different ensemble size\033[1;m')
+                        sys.exit(1)
+                    self.ne = min(tmp_ne) # Use the number of ensemble members in loaded ensemble
+                else:
+                    # Use the number of ensemble members specified in input file (may be fewer than loaded)
+                    self.ne = int(self.keys_en['ne'])
+                    if self.ne < min(tmp_ne):
+                        # pick correct number of ensemble members
+                        self.state = {key: val[:,:self.ne] for key, val in self.state.items()}
+                    else:
+                        print('\033[1;33mInput states are smaller than NE\033[1;m')
         self._ext_ml_info()
 
     def _ext_ml_info(self):

--- a/simulator/flow_rock.py
+++ b/simulator/flow_rock.py
@@ -22,7 +22,6 @@ from mako.runtime import Context
 from pylops.utils.wavelets import ricker
 from pylops.signalprocessing import Convolve1D
 import sys
-sys.path.append("/home/AD.NORCERESEARCH.NO/mlie/")
 from PyGRDECL.GRDECL_Parser import GRDECL_Parser  # https://github.com/BinWang0213/PyGRDECL/tree/master
 from scipy.interpolate import interp1d
 from scipy.interpolate import griddata
@@ -41,8 +40,6 @@ class flow_rock(flow):
         super().__init__(input_dict, filename, options)
         self._getpeminfo(input_dict)
 
-        self.dum_file_root = 'dummy.txt'
-        self.dum_entry = str(0)
         self.date_slack = None
         if 'date_slack' in input_dict:
             self.date_slack = int(input_dict['date_slack'])
@@ -738,7 +735,7 @@ class flow_avo(flow_rock):
 
         # The inherited simulator also has a run_fwd_sim. Call this.
         self.ensemble_member = member_i
-        self.pred_data = super().run_fwd_sim(state, member_i, del_folder=del_folder)
+        return super().run_fwd_sim(state, member_i, del_folder=del_folder)
 
     def call_sim(self, folder=None, wait_for_proc=False, run_reservoir_model=None, save_folder=None):
         # replace the sim2seis part (which is unusable) by avo based on Pylops
@@ -855,10 +852,7 @@ class flow_avo(flow_rock):
         # The properties in pem are only given in the active cells
         # indices of active cells:
 
-
         true_indices = np.where(grid['ACTNUM'])
-
-
 
         # Alt 2
         if len(self.pem.getBulkVel()) == len(true_indices[0]):
@@ -1037,7 +1031,6 @@ class flow_avo(flow_rock):
                                              f0=self.avo_config['frequency'])
 
 
-
         # Travel time corresponds to reflectivity series
         t = time_sample[:, :, 0:-1]
 
@@ -1095,8 +1088,6 @@ class flow_avo(flow_rock):
         # Two-way travel time of the top of the reservoir
         # TOPS[:, :, 0] corresponds to the depth profile of the reservoir top on the first layer
         top_res = 2 * self.TOPS[:, :, 0] / vp_shale
-
-
 
         # Cumulative traveling time through the reservoir in vertical direction
         cum_time_res = np.cumsum(2 * self.DZ / self.vp, axis=2) + top_res[:, :, np.newaxis]


### PR DESCRIPTION
NE in pipt file is now used instead of the whole loaded ensemble if this number is smaller than the number of ensemble members that are loaded. (It is not necessary to make a new prior file if you want to test with fewer members)
+bug fix in flow_rock 
