### PR TITLE
SLURM HPC MPIARRAY

### DIFF
--- a/simulator/eclipse.py
+++ b/simulator/eclipse.py
@@ -115,6 +115,7 @@ class eclipse:
         self.options['sim_path'] = ''
         self.options['sim_flag'] = ''
         self.options['mpi'] = ''
+        self.options['mpiarray'] = ''
         self.options['parsing-strictness'] = ''
         # Loop over options in SIMOPTIONS and extract the parameters we want
         if 'simoptions' in self.input_dict:
@@ -127,6 +128,8 @@ class eclipse:
                     self.options['sim_flag'] = self.input_dict['simoptions'][i][1]
                 if opt == 'mpi':
                     self.options['mpi'] = self.input_dict['simoptions'][i][1]
+                if opt == 'mpiarray':
+                    self.options['mpiarray'] = self.input_dict['simoptions'][i][1]
                 if opt == 'parsing-strictness':
                     self.options['parsing-strictness'] = self.input_dict['simoptions'][i][1]
         if 'sim_limit' in self.input_dict:


### PR DESCRIPTION
Added a keyword for HPC. Can be used as:
''
FWDSIM

HPC
TRUE

SIMOPTIONS
MPIARRAY
TRUE
''

The main change is that now when running slurm tasks on hpc cluster, for all ensemble members a single .sh file will be generated and a single sbatch command will be run on it. I tried to use as much as I could what you already implemented so it fits naturally. Now there is just one main new function SLURM_ARRAY_HPC_run that mimics SLURM_HPC_run. 

Also I kept the wait_for_jobs call after but it is not necessary anymore in this context. slurm waits for all tasks to be done in all cases when they are sent together. 

Previous behavior with SLURM_HPC_run generated a .sh and a sbatch command for every ensemble member. 

I believe this should improve scalability of PET in hpc context. 

Regarding test, I ran 3dBox tiny example with 2000 ensemble members using different amount of cpu and it seems to work fine. 