### PR TITLE
Fix default for use_ensemble option in organize_sparse_representation

### DIFF
--- a/pipt/misc_tools/extract_tools.py
+++ b/pipt/misc_tools/extract_tools.py
@@ -296,6 +296,7 @@ def organize_sparse_representation(info: Union[dict,list]) -> dict:
     sparse['keep_ca'] = info.get('keep_ca', False)
     sparse['inactive_value'] = info['inactive_value']
     sparse['use_ensemble'] = info.get('use_ensemble', None)
+    if sparse['use_ensemble'] == False: sparse['use_ensemble'] = None
 
     return sparse
 


### PR DESCRIPTION
If use_ensemble == no it should be set to None because of the choices in compress_manager